### PR TITLE
Set description as SQL text field, as it was rendered as RTE in BE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,11 @@ matrix:
   fast_finish: true
   include:
     - php: 7.0
-      env: TYPO3_VERSION=^7.6
+      env: TYPO3_VERSION=^8.7
     - php: 7.1
-      env: TYPO3_VERSION=^7.6
+      env: TYPO3_VERSION=^8.7
     - php: 7.2
-      env: TYPO3_VERSION=^7.6
-    - php: 7.0
-      env: TYPO3_VERSION=^8
-    - php: 7.1
-      env: TYPO3_VERSION=^8
-    - php: 7.2
-      env: TYPO3_VERSION=^8
+      env: TYPO3_VERSION=^8.7
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ before_script:
 script:
   - echo; echo "Running unit tests"; .Build/bin/phpunit --colors -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit/
   - echo; echo "Running php lint"; find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;
-  - echo; echo "Running PHP Coding Standards Fixer checks"; .Build/bin/php-cs-fixer fix Classes --config=Build/.php_cs.php --dry-run --using-cache=no -v
+  - echo; echo "Running PHP Coding Standards Fixer checks"; .Build/bin/php-cs-fixer fix Classes --config=Build/.php_cs.php --dry-run --using-cache=no -v --diff

--- a/Build/.php_cs.php
+++ b/Build/.php_cs.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+/**
+ * This file represents the configuration for Code Sniffing PSR-2-related
+ * automatic checks of coding guidelines
+ * Install @fabpot's great php-cs-fixer tool via
+ *
+ *  $ composer global require friendsofphp/php-cs-fixer
+ *
+ * And then simply run
+ *
+ *  $ php-cs-fixer fix --config Build/.php_cs
+ *
+ * inside the TYPO3 directory. Warning: This may take up to 10 minutes.
+ *
+ * For more information read:
+ * 	 http://www.php-fig.org/psr/psr-2/
+ * 	 http://cs.sensiolabs.org
+ */
+if (PHP_SAPI !== 'cli') {
+    die('This script supports command line usage only. Please check your command.');
+}
+// Define in which folders to search and which folders to exclude
+// Exclude some directories that are excluded by Git anyways to speed up the sniffing
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/../');
+// Return a Code Sniffing configuration using
+// all sniffers needed for PSR-2
+// and additionally:
+//  - Remove leading slashes in use clauses.
+//  - PHP single-line arrays should not have trailing comma.
+//  - Single-line whitespace before closing semicolon are prohibited.
+//  - Remove unused use statements in the PHP source code
+//  - Ensure Concatenation to have at least one whitespace around
+//  - Remove trailing whitespace at the end of blank lines.
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR2' => true,
+        'no_leading_import_slash' => true,
+        'no_trailing_comma_in_singleline_array' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_unused_imports' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'no_whitespace_in_blank_line' => true,
+        'ordered_imports' => true,
+        'single_quote' => true,
+        'no_empty_statement' => true,
+        'no_extra_consecutive_blank_lines' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_scalar' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'whitespace_after_comma_in_array' => true,
+        'function_typehint_space' => true,
+        'hash_to_slash_comment' => true,
+        'no_alias_functions' => true,
+        'lowercase_cast' => true,
+        'no_leading_namespace_whitespace' => true,
+        'native_function_casing' => true,
+        'self_accessor' => true,
+        'no_short_bool_cast' => true,
+        'no_unneeded_control_parentheses' => true
+    ])
+    ->setFinder($finder);

--- a/Build/.php_cs.php
+++ b/Build/.php_cs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * This file is part of the TYPO3 CMS project.
+ * This file is part of the socialservices project.
  *
  * It is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, either version 2

--- a/Classes/Controller/HelpdeskController.php
+++ b/Classes/Controller/HelpdeskController.php
@@ -2,7 +2,7 @@
 namespace JWeiland\Socialservices\Controller;
 
 /*
- * This file is part of the TYPO3 CMS project.
+ * This file is part of the socialservices project.
  *
  * It is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, either version 2
@@ -22,7 +22,6 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 /**
  * Class HelpdeskController
  *
- * @package socialservices
  * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
  */
 class HelpdeskController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController

--- a/Classes/Domain/Model/District.php
+++ b/Classes/Domain/Model/District.php
@@ -2,7 +2,7 @@
 namespace JWeiland\Socialservices\Domain\Model;
 
 /*
- * This file is part of the TYPO3 CMS project.
+ * This file is part of the socialservices project.
  *
  * It is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, either version 2
@@ -17,7 +17,6 @@ namespace JWeiland\Socialservices\Domain\Model;
 /**
  * Class District
  *
- * @package socialservices
  * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
  */
 class District extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity

--- a/Classes/Domain/Model/Helpdesk.php
+++ b/Classes/Domain/Model/Helpdesk.php
@@ -2,7 +2,7 @@
 namespace JWeiland\Socialservices\Domain\Model;
 
 /*
- * This file is part of the TYPO3 CMS project.
+ * This file is part of the socialservices project.
  *
  * It is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, either version 2
@@ -20,7 +20,6 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 /**
  * Class Helpdesk
  *
- * @package socialservices
  * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
  */
 class Helpdesk extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
@@ -426,7 +425,7 @@ class Helpdesk extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the barrierFree
      *
-     * @param boolean $barrierFree
+     * @param bool $barrierFree
      * @return void
      */
     public function setBarrierFree(bool $barrierFree)
@@ -435,7 +434,7 @@ class Helpdesk extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     }
 
     /**
-     * Returns the boolean state of barrierFree
+     * Returns the bool state of barrierFree
      *
      * @return bool
      */

--- a/Classes/Domain/Repository/HelpdeskRepository.php
+++ b/Classes/Domain/Repository/HelpdeskRepository.php
@@ -2,7 +2,7 @@
 namespace JWeiland\Socialservices\Domain\Repository;
 
 /*
- * This file is part of the TYPO3 CMS project.
+ * This file is part of the socialservices project.
  *
  * It is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, either version 2
@@ -22,7 +22,6 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 /**
  * Class HelpdeskRepository
  *
- * @package socialservices
  * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
  */
 class HelpdeskRepository extends Repository

--- a/Classes/Tca/CreateMap.php
+++ b/Classes/Tca/CreateMap.php
@@ -202,7 +202,7 @@ class CreateMap
      *
      * @param Location $location
      * @param string $address Formatted Address returned from Google
-     * @return integer insert UID
+     * @return int insert UID
      */
     public function createNewPoiCollection(Location $location, string $address): int
     {
@@ -307,5 +307,4 @@ class CreateMap
             );
         }
     }
-
 }

--- a/Classes/Tca/CreateMap.php
+++ b/Classes/Tca/CreateMap.php
@@ -2,7 +2,7 @@
 namespace JWeiland\Socialservices\Tca;
 
 /*
- * This file is part of the TYPO3 CMS project.
+ * This file is part of the socialservices project.
  *
  * It is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, either version 2
@@ -28,7 +28,6 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 /**
- * @package socialservices
  * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
  */
 class CreateMap
@@ -120,7 +119,7 @@ class CreateMap
      * While updating a record only the changed fields will be in $fieldArray
      *
      * @param string $table
-     * @param integer $uid
+     * @param int $uid
      * @return array|NULL Returns the row if found, otherwise NULL
      */
     public function getFullRecord(string $table, int $uid)
@@ -148,7 +147,7 @@ class CreateMap
      * try to find a similar poiCollection
      *
      * @param array $location
-     * @return integer The UID of the PoiCollection. 0 if not found
+     * @return int The UID of the PoiCollection. 0 if not found
      */
     public function findPoiByLocation(array $location): int
     {
@@ -171,7 +170,7 @@ class CreateMap
     /**
      * update socialservices record
      *
-     * @param integer $poi
+     * @param int $poi
      * @return void
      */
     public function updateCurrentRecord(int $poi)

--- a/Tests/Unit/Domain/Model/HelpdeskTest.php
+++ b/Tests/Unit/Domain/Model/HelpdeskTest.php
@@ -770,7 +770,7 @@ class HelpdeskTest extends UnitTestCase
      * @test
      */
     public function setCategoriesSetsCategories() {
-        $object = new \JWeiland\Maps2\Domain\Model\Category();
+        $object = new \TYPO3\CMS\Extbase\Domain\Model\Category();
         $objectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
         $objectStorage->attach($object);
         $this->subject->setCategories($objectStorage);
@@ -788,7 +788,7 @@ class HelpdeskTest extends UnitTestCase
         $objectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
         $this->subject->setCategories($objectStorage);
 
-        $object = new \JWeiland\Maps2\Domain\Model\Category();
+        $object = new \TYPO3\CMS\Extbase\Domain\Model\Category();
         $this->subject->addCategory($object);
 
         $objectStorage->attach($object);
@@ -803,7 +803,7 @@ class HelpdeskTest extends UnitTestCase
      * @test
      */
     public function removeCategoryRemovesOneCategory() {
-        $object = new \JWeiland\Maps2\Domain\Model\Category();
+        $object = new \TYPO3\CMS\Extbase\Domain\Model\Category();
         $objectStorage = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
         $objectStorage->attach($object);
         $this->subject->setCategories($objectStorage);

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 		"source": "https://github.com/jweiland-net/socialservices"
 	},
 	"require": {
-		"typo3/cms-core": "^8.7"
+		"typo3/cms-core": "^8.7",
+		"typo3/cms": "^8"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^2",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
 		"typo3/cms-core": "^8.7"
 	},
 	"require-dev": {
-		"friendsofphp/php-cs-fixer": "^2.0",
-		"nimut/testing-framework": "^2.0 || ^3.0"
+		"friendsofphp/php-cs-fixer": "^2",
+		"nimut/testing-framework": "^3"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -18,7 +18,7 @@ CREATE TABLE tx_socialservices_domain_model_helpdesk (
 	email varchar(255) DEFAULT '' NOT NULL,
 	website varchar(255) DEFAULT '' NOT NULL,
 	barrier_free tinyint(1) unsigned DEFAULT '0' NOT NULL,
-	description varchar(255) DEFAULT '' NOT NULL,
+	description text NOT NULL,
 	tx_maps2_uid int(11) DEFAULT '0' NOT NULL,
 	facebook varchar(255) DEFAULT '' NOT NULL,
 	twitter varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
In our project we need more than 255 letters for field description. So, we set that field to SQL type TEXT. The customers maximum length of this field will be configured in our project individual site-package